### PR TITLE
docs: fix typo in README flake.nix example ("input" → "inputs")

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ For example:
 
 ```nix
 {
-  input.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  input.smlsharp.url = "github:smlsharp/nixpkgs";
-  input.smlsharp.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.smlsharp.url = "github:smlsharp/nixpkgs";
+  inputs.smlsharp.inputs.nixpkgs.follows = "nixpkgs";
   outputs =
     { self, nixpkgs, smlsharp }:
     {


### PR DESCRIPTION
This PR corrects a typo in the README. In the flake.nix code snippet, the field was mistakenly written as input instead of the correct inputs. No other changes have been made.